### PR TITLE
Expand UMG catalog with additional domains

### DIFF
--- a/umg_domains.csv
+++ b/umg_domains.csv
@@ -10,3 +10,23 @@ polydor.co.uk,Label,United Kingdom,Polydor Records UK site
 republicrecords.com,Label,United States,Republic Records label site
 arianagrande.com,Artist,Global,Ariana Grande official artist domain
 billieeilish.com,Artist,Global,Billie Eilish official artist domain
+umusic.ca,UMG Corporate,Canada,Canadian market portal highlighting UMG artists
+umusic.com.au,UMG Corporate,Australia,Australian consumer portal for Universal Music Australia releases
+universal-music.co.jp,UMG Corporate,Japan,Universal Music Japan official site
+udiscovermusic.com,UMG Corporate,Global,Editorial hub operated by UMG featuring catalog storytelling
+capitolrecords.com,Label,United States,Capitol Music Group flagship label site
+geffen.com,Label,United States,Geffen Records label home under Interscope Geffen A&M
+motownrecords.com,Label,United States,Motown Records label site
+decca.com,Label,United Kingdom,Decca Records classical label site
+deutschegrammophon.com,Label,Germany,Deutsche Grammophon classical label site
+virginmusicgroup.com,Label,Global,Virgin Music Group distribution and services hub
+universalproductionmusic.com,Label,Global,Universal Production Music licensing catalog portal
+taylorswift.com,Artist,Global,Taylor Swift official site under Republic Records
+justinbiebermusic.com,Artist,Global,Justin Bieber official domain under Def Jam Recordings
+theweeknd.com,Artist,Global,The Weeknd official artist site with Republic Records
+ladygaga.com,Artist,Global,Lady Gaga official site under Interscope Records
+postmalone.com,Artist,Global,Post Malone official site for Republic Records releases
+oliviarodrigo.com,Artist,Global,Olivia Rodrigo official site under Geffen Records
+shawnmendesofficial.com,Artist,Global,Shawn Mendes official site through Island Records
+imaginedragonsmusic.com,Artist,Global,Imagine Dragons official site under Kidinakorner/Interscope
+lorde.co.nz,Artist,New Zealand,Lorde official site for releases via Universal Music New Zealand


### PR DESCRIPTION
## Summary
- add regional corporate portals for Canada, Australia, and Japan to the UMG domain catalog
- expand label coverage with Capitol Records, Geffen, Motown, Decca, Deutsche Grammophon, Virgin Music Group, and Universal Production Music
- document additional priority artist domains from Republic, Interscope, and other UMG labels

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e469ff5bbc8323be790f495214cfa2